### PR TITLE
chapter list

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -2,7 +2,7 @@
 layout: layouts/base.liquid
 pageTitle: My projects
 pagination:
-  data: collections.posts
+  data: collections.article
   size: 5
   alias: entries
   reverse: true
@@ -25,7 +25,7 @@ pagination:
       <p class="project-entry-lead">
         {{ post.data.lead | safe }}
       </p>
-      
+
       <a class="read-more-link" href="{{ post.url }}">Read more <span aria-hidden="true">→</span></a>
     {% endif %}
   </li>

--- a/posts/bouquet-preview-app-case-study/introduction.md
+++ b/posts/bouquet-preview-app-case-study/introduction.md
@@ -5,12 +5,7 @@ pageTitle: 'Case study: bouquet preview app'
 lead: "A collection of common CSS mistakes, and how to fix them."
 socialImage: /posts/images/csshell/csshell.jpg
 socialImageWebP: /posts/images/csshell/csshell.webp
-tags: posts
-pagination:
-  data: collections.floral
-  size: 10
-  reverse: true
-  addAllPagesToCollections: true
+tags: article
 ---
 
 Intro
@@ -18,6 +13,8 @@ Intro
 Page:
 <ol>
 {% for post in collections.floral %}
+{% unless post.data.tags contains 'article' %}
   <li><a href="{{ post.url | url }}">{{ post.data.pageTitle }}</a></li>
+{% endunless %}
 {% endfor %}
 </ol>

--- a/posts/css-hell.md
+++ b/posts/css-hell.md
@@ -1,6 +1,6 @@
 ---
 layout: layouts/project.liquid
-tags: posts
+tags: article
 date: 2022-02-07T15:45:00
 pageTitle: 'CSS Hell'
 lead: "A collection of common CSS mistakes, and how to fix them."

--- a/posts/mol-bubi-research-case-study.md
+++ b/posts/mol-bubi-research-case-study.md
@@ -1,6 +1,6 @@
 ---
 layout: layouts/project.liquid
-tags: posts
+tags: article
 date: 2022-02-02T18:00:00
 pageTitle: 'Research case study: Mol Bubi'
 lead: "Mol Bubi is a bike-sharing system in Hungary. I have worked on this project as part of a course called MOME Insight."


### PR DESCRIPTION
it was giving me an error 

```
[11ty] > Dependency Cycle Found: ___TAG___all -> ./posts/bouquet-preview-app-case-study/introduction.md -> ___TAG___floral -> ./posts/bouquet-preview-app-case-study/introduction.md
```

i fixed it, the chapter list is there, but I am not sure that is working properly since `collections.floral` is anyway getting all results and I had to filter with an `if`.
The same was happening with the `collections.posts`, it was also including `floral`. So I added the `article` tag and it seems to work at least on the main page.
Maybe I don't understand how collection works so better to ask in the `11ty` discussion again. I am also interested in knowing what the solution could be.



